### PR TITLE
Add cron dependency

### DIFF
--- a/project-autumn-pi/package-lock.json
+++ b/project-autumn-pi/package-lock.json
@@ -36,6 +36,15 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/cron": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-1.7.2.tgz",
+      "integrity": "sha512-AEpNLRcsVSc5AdseJKNHpz0d4e8+ow+abTaC0fKDbAU86rF1evoFF0oC2fV9FdqtfVXkG2LKshpLTJCFOpyvTg==",
+      "requires": {
+        "@types/node": "*",
+        "moment": ">=2.14.0"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -47,6 +56,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "13.9.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.8.tgz",
+      "integrity": "sha512-1WgO8hsyHynlx7nhP1kr0OFzsgKz5XDQL+Lfc3b1Q3qIln/n8cKD4m09NJ0+P1Rq7Zgnc7N0+SsMnoD1rEb0kA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.26.0",
@@ -272,6 +286,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "cron": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
+      "integrity": "sha512-Gk2c4y6xKEO8FSAUTklqtfSr7oTq0CiPQeLBG5Fl0qoXpZyMcj1SG59YL+hqq04bu6/IuEA7lMkYDAplQNKkyg==",
+      "requires": {
+        "moment-timezone": "^0.5.x"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -818,6 +840,19 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "requires": {
+        "moment": ">= 2.9.0"
       }
     },
     "ms": {

--- a/project-autumn-pi/package.json
+++ b/project-autumn-pi/package.json
@@ -15,5 +15,9 @@
     "eslint": "^6.8.0",
     "prettier": "^2.0.2",
     "typescript": "^3.8.3"
+  },
+  "dependencies": {
+    "@types/cron": "^1.7.2",
+    "cron": "^1.8.2"
   }
 }

--- a/project-autumn-pi/src/index.ts
+++ b/project-autumn-pi/src/index.ts
@@ -1,0 +1,12 @@
+import { CronJob } from "cron";
+
+let n = 1;
+
+const job = new CronJob("* * * * * *", () => {
+  console.log(
+    `This message will print every second.\nThis has printed ${n} times.\n`
+  );
+  n++;
+});
+
+job.start();


### PR DESCRIPTION
This PR adds [cron](https://www.npmjs.com/package/cron) and its [types](https://www.npmjs.com/package/@types/cron) as dependecies.

This allows for scheduling cronjobs within the node app. This is good because it allows me to run the app on boot and not touch the cron table.

Also added some dummy code as a cronjob