### PR TITLE
Add Sensor typing to Firestore

### DIFF
--- a/project-autumn-pi/src/index.ts
+++ b/project-autumn-pi/src/index.ts
@@ -28,7 +28,7 @@ const firestore: firebase.firestore.Firestore = getFirestoreInstance(
 const readAndPersistTemperatures = (): void => {
   const allDS18B20Sensors: DS18B20[] = ds18b20Raspi.readAllC();
 
-  const ds18b20Sensors = transformDS18B20ArrayToSensorArray(
+  const ds18b20Sensors: Sensor[] = transformDS18B20ArrayToSensorArray(
     allDS18B20Sensors,
     firestore
   );

--- a/project-autumn-pi/src/types/Sensor.ts
+++ b/project-autumn-pi/src/types/Sensor.ts
@@ -1,6 +1,11 @@
 export type SensorData = { value: number; timestamp: number };
 export type DS18B20 = { id: string; t: number };
 
+export enum SensorType {
+  Temperature = 'temperature',
+  Moisture = 'moisture',
+}
+
 export default class Sensor {
   private id: string;
   private name: string;

--- a/project-autumn-pi/src/types/Sensor.ts
+++ b/project-autumn-pi/src/types/Sensor.ts
@@ -10,14 +10,17 @@ export default class Sensor {
   private id: string;
   private name: string;
   private connection: firebase.firestore.Firestore;
+  private type: SensorType;
 
   constructor(
     id: string,
     name: string,
+    type: SensorType,
     connection: firebase.firestore.Firestore
   ) {
     this.id = id;
     this.name = name;
+    this.type = type;
     this.connection = connection;
     this.createDocument();
   }
@@ -31,7 +34,7 @@ export default class Sensor {
       this.connection
         .collection("sensors")
         .doc(this.id)
-        .set({ name: this.name });
+        .set({ name: this.name, type: this.type });
       return true;
     } catch (exception) {
       console.error(exception);

--- a/project-autumn-pi/src/utils/ds18b20.ts
+++ b/project-autumn-pi/src/utils/ds18b20.ts
@@ -1,5 +1,5 @@
 import { sensorIdNameMap } from "../consts/ds18b20";
-import Sensor, { DS18B20, SensorData } from "../types/Sensor";
+import Sensor, { DS18B20, SensorData, SensorType } from "../types/Sensor";
 
 export const getNameFromSensorId = (id: string): string | false => {
   const value = sensorIdNameMap.get(id);
@@ -14,7 +14,7 @@ export const transformDS18B20ToSensor = (
   const { id } = ds18b20;
   const name = getNameFromSensorId(id);
   if (!name) throw Error(`No corresponding name for DS18B20 id: ${id}`);
-  return new Sensor(id, name, connection);
+  return new Sensor(id, name, SensorType.Temperature, connection);
 };
 
 export const transformDS18B20ArrayToSensorArray = (

--- a/project-autumn-web/src/App.tsx
+++ b/project-autumn-web/src/App.tsx
@@ -33,8 +33,8 @@ function App() {
             .get()
             .then(querySnapshot => {
                 querySnapshot.forEach(doc => {
-                    const { name } = doc.data();
-                    sensorArray.push(new Sensor(doc.id, name, firestore));
+                    const { name, type } = doc.data();
+                    sensorArray.push(new Sensor(doc.id, name, type, firestore));
                 });
                 setSensors(sensorArray);
             });

--- a/project-autumn-web/src/components/SensorCard.tsx
+++ b/project-autumn-web/src/components/SensorCard.tsx
@@ -1,15 +1,10 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import Sensor, { SensorData } from "../types/Sensor";
-
-export enum SensorCardVariant {
-    Temperature,
-    Moisture
-}
+import Sensor, { SensorData, SensorType } from "../types/Sensor";
 
 interface Props {
     sensor: Sensor;
-    variant: SensorCardVariant;
+    variant: SensorType;
 }
 
 const Timestamp = styled.div`
@@ -31,10 +26,10 @@ const SensorCard = ({ sensor, variant }: Props) => {
 
     const getVariantUnits = (value: number) => {
         switch (variant) {
-            case SensorCardVariant.Temperature:
+            case SensorType.Temperature:
                 return <small>{value}&deg;C</small>;
 
-            case SensorCardVariant.Moisture:
+            case SensorType.Moisture:
                 return <small>{value ? "Moist" : "Dry"}</small>;
 
             default:

--- a/project-autumn-web/src/components/SensorList.tsx
+++ b/project-autumn-web/src/components/SensorList.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import Sensor from "../types/Sensor";
-import SensorCard, { SensorCardVariant } from "./SensorCard";
+import SensorCard from "./SensorCard";
 
 const SensorListContainer = styled.div`
     display: flex;
@@ -19,7 +19,7 @@ const SensorList = ({ sensors }: Props) => {
                 <SensorCard
                     key={sensor.getId()}
                     sensor={sensor}
-                    variant={SensorCardVariant.Temperature}
+                    variant={sensor.getType()}
                 />
             ))}
         </SensorListContainer>

--- a/project-autumn-web/src/types/Sensor.ts
+++ b/project-autumn-web/src/types/Sensor.ts
@@ -1,5 +1,10 @@
 export type SensorData = { value: number; timestamp: number };
 
+export enum SensorType {
+    Temperature = "temperature",
+    Moisture = "moisture"
+}
+
 export default class Sensor {
     private id: string;
     private name: string;

--- a/project-autumn-web/src/types/Sensor.ts
+++ b/project-autumn-web/src/types/Sensor.ts
@@ -8,15 +8,18 @@ export enum SensorType {
 export default class Sensor {
     private id: string;
     private name: string;
+    private type: SensorType;
     private connection: firebase.firestore.Firestore;
 
     constructor(
         id: string,
         name: string,
+        type: SensorType,
         connection: firebase.firestore.Firestore
     ) {
         this.id = id;
         this.name = name;
+        this.type = type;
         this.connection = connection;
     }
 
@@ -26,6 +29,10 @@ export default class Sensor {
 
     public getName(): string {
         return this.name;
+    }
+
+    public getType(): SensorType {
+        return this.type;
     }
 
     public async fetchData(): Promise<SensorData[] | false> {


### PR DESCRIPTION
This PR adds sensor type fields to the Sensor classes. This also adds the sensor type as a field in Firestore when the document is created.