### PR TITLE
Add min and max to Sensor

### DIFF
--- a/project-autumn-pi/src/index.ts
+++ b/project-autumn-pi/src/index.ts
@@ -42,7 +42,7 @@ const eventLoop = (): void => {
   readAndPersistTemperatures();
 };
 
-// Runs the event loop every 30 minutes
-const app: CronJob = new CronJob("*/30 * * * * *", eventLoop);
+// Runs the event loop at the top of every hour
+const app: CronJob = new CronJob("0 * * * * *", eventLoop);
 
 app.start();

--- a/project-autumn-pi/src/types/Sensor.ts
+++ b/project-autumn-pi/src/types/Sensor.ts
@@ -2,25 +2,31 @@ export type SensorData = { value: number; timestamp: number };
 export type DS18B20 = { id: string; t: number };
 
 export enum SensorType {
-  Temperature = 'temperature',
-  Moisture = 'moisture',
+  Temperature = "temperature",
+  Moisture = "moisture",
 }
 
 export default class Sensor {
   private id: string;
   private name: string;
   private connection: firebase.firestore.Firestore;
+  private min: number;
+  private max: number;
   private type: SensorType;
 
   constructor(
     id: string,
     name: string,
     type: SensorType,
+    min: number,
+    max: number,
     connection: firebase.firestore.Firestore
   ) {
     this.id = id;
     this.name = name;
     this.type = type;
+    this.min = min;
+    this.max = max;
     this.connection = connection;
     this.createDocument();
   }
@@ -31,10 +37,12 @@ export default class Sensor {
 
   private createDocument(): boolean {
     try {
-      this.connection
-        .collection("sensors")
-        .doc(this.id)
-        .set({ name: this.name, type: this.type });
+      this.connection.collection("sensors").doc(this.id).set({
+        name: this.name,
+        type: this.type,
+        min: this.min,
+        max: this.max,
+      });
       return true;
     } catch (exception) {
       console.error(exception);

--- a/project-autumn-pi/src/utils/ds18b20.ts
+++ b/project-autumn-pi/src/utils/ds18b20.ts
@@ -1,6 +1,9 @@
 import { sensorIdNameMap } from "../consts/ds18b20";
 import Sensor, { DS18B20, SensorData, SensorType } from "../types/Sensor";
 
+const DEFAULT_MIN = 20;
+const DEFAULT_MAX = 30;
+
 export const getNameFromSensorId = (id: string): string | false => {
   const value = sensorIdNameMap.get(id);
   if (value === undefined) return false;
@@ -14,7 +17,14 @@ export const transformDS18B20ToSensor = (
   const { id } = ds18b20;
   const name = getNameFromSensorId(id);
   if (!name) throw Error(`No corresponding name for DS18B20 id: ${id}`);
-  return new Sensor(id, name, SensorType.Temperature, connection);
+  return new Sensor(
+    id,
+    name,
+    SensorType.Temperature,
+    DEFAULT_MIN,
+    DEFAULT_MAX,
+    connection
+  );
 };
 
 export const transformDS18B20ArrayToSensorArray = (

--- a/project-autumn-web/src/App.tsx
+++ b/project-autumn-web/src/App.tsx
@@ -33,8 +33,10 @@ function App() {
             .get()
             .then(querySnapshot => {
                 querySnapshot.forEach(doc => {
-                    const { name, type } = doc.data();
-                    sensorArray.push(new Sensor(doc.id, name, type, firestore));
+                    const { name, type, min, max } = doc.data();
+                    sensorArray.push(
+                        new Sensor(doc.id, name, type, min, max, firestore)
+                    );
                 });
                 setSensors(sensorArray);
             });

--- a/project-autumn-web/src/components/SensorCard.tsx
+++ b/project-autumn-web/src/components/SensorCard.tsx
@@ -39,7 +39,9 @@ const SensorCard = ({ sensor, variant }: Props) => {
 
     if (!latestData) return <p>Loading</p>;
 
-    const warning = latestData.value < 20;
+    const warning =
+        sensor.getMin() > latestData.value ||
+        latestData.value > sensor.getMax();
 
     const Card = styled.div`
         display: flex;

--- a/project-autumn-web/src/types/Sensor.ts
+++ b/project-autumn-web/src/types/Sensor.ts
@@ -9,17 +9,23 @@ export default class Sensor {
     private id: string;
     private name: string;
     private type: SensorType;
+    private min: number;
+    private max: number;
     private connection: firebase.firestore.Firestore;
 
     constructor(
         id: string,
         name: string,
         type: SensorType,
+        min: number,
+        max: number,
         connection: firebase.firestore.Firestore
     ) {
         this.id = id;
         this.name = name;
         this.type = type;
+        this.min = min;
+        this.max = max;
         this.connection = connection;
     }
 
@@ -33,6 +39,14 @@ export default class Sensor {
 
     public getType(): SensorType {
         return this.type;
+    }
+
+    public getMin(): number {
+        return this.min;
+    }
+
+    public getMax(): number {
+        return this.max;
     }
 
     public async fetchData(): Promise<SensorData[] | false> {


### PR DESCRIPTION
This PR adds a min and a max field to the Firestore documents. These are used by the web-app to display the SensorCard in a warning state if the measured value violates the bounds.

Also changed the event loop to fire at the top of every hour