### PR TITLE
Fix text alignment in SensorCard

### DIFF
--- a/project-autumn-web/src/components/SensorCard.tsx
+++ b/project-autumn-web/src/components/SensorCard.tsx
@@ -48,6 +48,7 @@ const SensorCard = ({ sensor, variant }: Props) => {
         flex-grow: 1;
         flex-direction: column;
         align-items: center;
+        text-align: center;
         background: ${warning ? "#B01622" : "#0A6800"};
         margin: 1rem;
         padding: 1rem;


### PR DESCRIPTION
Fixes #34 

BEFORE:
<img width="893" alt="Screen Shot 2020-04-04 at 9 21 35 am" src="https://user-images.githubusercontent.com/20939486/78409566-bd648280-7655-11ea-81b3-7c32921d1817.png">

AFTER:
<img width="897" alt="Screen Shot 2020-04-04 at 9 20 27 am" src="https://user-images.githubusercontent.com/20939486/78409576-c2293680-7655-11ea-95c2-c5716a2be6be.png">
