### PR TITLE
Stop showing white page edges on mobile

### DIFF
--- a/project-autumn-web/src/components/SensorCard.tsx
+++ b/project-autumn-web/src/components/SensorCard.tsx
@@ -45,10 +45,13 @@ const SensorCard = ({ sensor, variant }: Props) => {
 
     const Card = styled.div`
         display: flex;
-        flex-grow: 1;
         flex-direction: column;
         align-items: center;
         text-align: center;
+        flex-basis: 40%;
+        @media (max-width: 650px) {
+            flex-basis: 100%;
+        }
         background: ${warning ? "#B01622" : "#0A6800"};
         margin: 1rem;
         padding: 1rem;

--- a/project-autumn-web/src/components/SensorList.tsx
+++ b/project-autumn-web/src/components/SensorList.tsx
@@ -6,6 +6,7 @@ import SensorCard from "./SensorCard";
 const SensorListContainer = styled.div`
     display: flex;
     justify-content: space-around;
+    flex-wrap: wrap;
 `;
 
 interface Props {


### PR DESCRIPTION
This PR fixes #35 

This was being caused by the `<SensorCard>` components overflowing the `<body>`.

Fixed this by using `flex-basis` and `flex-wrap`

BEFORE:
<img width="420" alt="Screen Shot 2020-04-04 at 9 23 32 am" src="https://user-images.githubusercontent.com/20939486/78410258-7f685e00-7657-11ea-8f02-685c8fc455d4.png">

AFTER:
<img width="1071" alt="Screen Shot 2020-04-04 at 9 32 19 am" src="https://user-images.githubusercontent.com/20939486/78410273-83947b80-7657-11ea-9e04-abe948867946.png">
<img width="680" alt="Screen Shot 2020-04-04 at 9 32 10 am" src="https://user-images.githubusercontent.com/20939486/78410274-84c5a880-7657-11ea-939f-e2fd051d06ec.png">
