### PR TITLE
Style SensorCards a bit nicer

### DIFF
--- a/project-autumn-web/src/components/SensorCard.tsx
+++ b/project-autumn-web/src/components/SensorCard.tsx
@@ -20,7 +20,7 @@ const SensorCard = ({ sensor, variant }: Props) => {
         });
     }, [sensor]);
 
-    const getVariantUnits = (value: number) => {
+    const addVariantUnitsToValue = (value: number) => {
         switch (variant) {
             case SensorType.Temperature:
                 return <small>{value}&deg;C</small>;
@@ -56,9 +56,7 @@ const SensorCard = ({ sensor, variant }: Props) => {
     `;
     return (
         <Card>
-            <strong>
-                {getVariantUnits(latestData.value)}
-            </strong>
+            <strong>{addVariantUnitsToValue(latestData.value)}</strong>
             <h2>{sensor.getName()}</h2>
             <Timestamp>
                 {new Date(latestData.timestamp).toLocaleString()}

--- a/project-autumn-web/src/components/SensorCard.tsx
+++ b/project-autumn-web/src/components/SensorCard.tsx
@@ -11,10 +11,6 @@ const Timestamp = styled.div`
     font-size: 0.5em;
 `;
 
-const Section = styled.div`
-    padding: 1rem 0;
-`;
-
 const SensorCard = ({ sensor, variant }: Props) => {
     const [latestData, setLatestData] = useState<SensorData | undefined>();
 
@@ -49,23 +45,24 @@ const SensorCard = ({ sensor, variant }: Props) => {
         align-items: center;
         text-align: center;
         flex-basis: 40%;
+        justify-content: space-between;
         @media (max-width: 650px) {
             flex-basis: 100%;
         }
         background: ${warning ? "#B01622" : "#0A6800"};
         margin: 1rem;
-        padding: 1rem;
+        padding: 1.5rem 1rem;
         border-radius: 4px;
     `;
     return (
         <Card>
-            <Section>{getVariantUnits(latestData.value)}</Section>
-            <Section>{sensor.getName()}</Section>
-            <Section>
-                <Timestamp>
-                    {new Date(latestData.timestamp).toLocaleString()}
-                </Timestamp>
-            </Section>
+            <strong>
+                {getVariantUnits(latestData.value)}
+            </strong>
+            <h2>{sensor.getName()}</h2>
+            <Timestamp>
+                {new Date(latestData.timestamp).toLocaleString()}
+            </Timestamp>
         </Card>
     );
 };


### PR DESCRIPTION
This PR adds some basic styling to the `<SensorCard>` components. Fixes #37 

Also renames the function that adds the units to to value depending on it's variant

BEFORE:
<img width="1059" alt="Screen Shot 2020-04-04 at 9 45 12 am" src="https://user-images.githubusercontent.com/20939486/78410771-1aae0300-7659-11ea-997b-5d804a3b80c8.png">
<img width="575" alt="Screen Shot 2020-04-04 at 9 45 04 am" src="https://user-images.githubusercontent.com/20939486/78410774-1bdf3000-7659-11ea-9df7-af32a85f625c.png">

AFTER:
<img width="590" alt="Screen Shot 2020-04-04 at 9 44 54 am" src="https://user-images.githubusercontent.com/20939486/78410784-24376b00-7659-11ea-9816-55fc362e7302.png">
<img width="1134" alt="Screen Shot 2020-04-04 at 9 44 48 am" src="https://user-images.githubusercontent.com/20939486/78410787-25689800-7659-11ea-8cf1-127e0f0d99d7.png">
